### PR TITLE
Patch/1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <version>1.7.0</version>
   </parent>
   <artifactId>flowstore</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <properties>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/groovy/life/qbic/flowstore/database/MariaDBStorage.groovy
+++ b/src/main/groovy/life/qbic/flowstore/database/MariaDBStorage.groovy
@@ -20,6 +20,7 @@ import javax.inject.Singleton
 import java.sql.Clob
 import java.text.DateFormat
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 
 @Log4j2
 @Singleton
@@ -133,7 +134,7 @@ class MariaDBStorage implements Workflows, AutoCloseable{
             revision, duration, success, resume, nextflowVersion, exitStatus, errorMessage) 
             values (
                 $primaryKeyRun,
-                ${ utcDateFormat.parse(metaData.workflow.'start' as String) },
+                ${ safelyConvertDate(metaData.workflow.'start' as String) },
                 ${JsonOutput.toJson(metaData.'parameters')},
                 ${metaData.workflow.'workDir'},
                 ${metaData.workflow.'container'},
@@ -147,6 +148,18 @@ class MariaDBStorage implements Workflows, AutoCloseable{
                 ${metaData.workflow.'exitStatus'},
                 ${metaData.workflow.'errorMessage'}
             );""")
+    }
+
+    private static def safelyConvertDate(String date){
+        try {
+            toUTCTime(date)
+        } catch (Exception e){
+            // Nextflow changed from Date to OffsetDateTime
+            log.info "Date seems to be an offset date time..."
+            def formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+            return formatter.parse(date)
+        }
+
     }
 
     private Integer storeRunInfo(RunInfo runInfo) {


### PR DESCRIPTION
Support timezoned timestamps, as with newer Nextflow versions, parsing of Workflow Metadata time fails:
https://github.com/nextflow-io/nextflow/commit/6f4a2e28475800e233595dbe7d090d30cd0d7b79

